### PR TITLE
updated links for jcsmp GH repo rename

### DIFF
--- a/src/pages/tutorials/jcsmp/active-flow-indication.md
+++ b/src/pages/tutorials/jcsmp/active-flow-indication.md
@@ -75,5 +75,5 @@ flowOne.close(); // Active flow indication event for flowTwo fires now that flow
 
 ## Learn More
 
-* Related Source Code: [QueueProvisionAndRequestActiveFlowIndication.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/features/QueueProvisionAndRequestActiveFlowIndication.java)
+* Related Source Code: [QueueProvisionAndRequestActiveFlowIndication.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/QueueProvisionAndRequestActiveFlowIndication.java)
 * [Solace Feature Documentation](https://docs.solace.com/Solace-PubSub-Messaging-APIs/API-Developer-Guide/Creating-Flows.htm)

--- a/src/pages/tutorials/jcsmp/browsing-queues.md
+++ b/src/pages/tutorials/jcsmp/browsing-queues.md
@@ -52,5 +52,5 @@ do {
 
 ## Learn More
 
-* Related Source Code: [QueueProvisionAndBrowse.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/features/QueueProvisionAndBrowse.java)
+* Related Source Code: [QueueProvisionAndBrowse.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/QueueProvisionAndBrowse.java)
 * [Solace Feature Documentation](https://docs.solace.com/Solace-PubSub-Messaging-APIs/API-Developer-Guide/Creating-Flows.htm)

--- a/src/pages/tutorials/jcsmp/confirmed-delivery.md
+++ b/src/pages/tutorials/jcsmp/confirmed-delivery.md
@@ -156,17 +156,17 @@ class PubCallback implements JCSMPStreamingPublishCorrelatingEventHandler {
 
 ## Summarizing
 
-The full source code for this example is available in [GitHub](https://github.com/SolaceSamples/solace-samples-java). If you combine the example source code shown above results in the following source:
+The full source code for this example is available in [GitHub](https://github.com/SolaceSamples/solace-samples-java-jcsmp). If you combine the example source code shown above results in the following source:
 
-* [ConfirmedPublish.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/ConfirmedPublish.java)
+* [ConfirmedPublish.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/ConfirmedPublish.java)
 
 ### Getting the Source
 
 This tutorial is available in GitHub.  To get started, clone the GitHub repository containing the Solace samples.
 
 ```
-git clone https://github.com/SolaceSamples/solace-samples-java
-cd solace-samples-java
+git clone https://github.com/SolaceSamples/solace-samples-java-jcsmp
+cd solace-samples-java-jcsmp
 ```
 
 ### Building

--- a/src/pages/tutorials/jcsmp/message-replay.md
+++ b/src/pages/tutorials/jcsmp/message-replay.md
@@ -195,7 +195,7 @@ public void onException(JCSMPException exception) {
 
 ## Running the Sample
 
-Follow the instructions to [build the samples](https://github.com/SolaceSamples/solace-samples-java/blob/master/README.md#build-the-samples).
+Follow the instructions to [build the samples](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/README.md#build-the-samples).
 
 Before running this sample, be sure that Message Replay is enabled in the Message VPN. Also, messages must have been published to the replay log for the queue that is used. The "QueueProducer" sample can be used to create and publish messages to the queue. The "QueueConsumer" sample can be used to drain the queue so that replay is performed on an empty queue and observed by this sample. Both samples are from the [Persistence with Queues](../persistence-with-queues/) tutorial.
 
@@ -223,5 +223,5 @@ This will replay all logged messages including the live one published in step 2.
 ![Screenshot: Initiating Replay using Solace PubSub+ Manager](../../../images/screenshots/initiate-replay.png)
 
 ## Learn More
-* Related Source Code: [MessageReplay.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/features/MessageReplay.java)
+* Related Source Code: [MessageReplay.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/MessageReplay.java)
 * [Solace Feature Documentation](https://docs.solace.com/Overviews/Message-Replay-Overview.htm)

--- a/src/pages/tutorials/jcsmp/message-selectors.md
+++ b/src/pages/tutorials/jcsmp/message-selectors.md
@@ -48,7 +48,7 @@ for (String p : new String[] { "macaroni", "fettuccini", "farfalle", "fiori", "r
 
 ## Learn More
 
-* Related Source Code: [MessageSelectorsOnQueue.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/features/MessageSelectorsOnQueue.java)
+* Related Source Code: [MessageSelectorsOnQueue.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/MessageSelectorsOnQueue.java)
 * [Solace Feature Documentation](https://docs.solace.com/Solace-JMS-API/Selectors.htm?Highlight=selector)
 
 

--- a/src/pages/tutorials/jcsmp/persistence-with-queues.md
+++ b/src/pages/tutorials/jcsmp/persistence-with-queues.md
@@ -199,10 +199,10 @@ try {
 
 ## Summarizing
 
-The full source code for this example is available in [GitHub](https://github.com/SolaceSamples/solace-samples-java). If you combine the example source code shown above results in the following source:
+The full source code for this example is available in [GitHub](https://github.com/SolaceSamples/solace-samples-java-jcsmp). If you combine the example source code shown above results in the following source:
 
-* [QueueProducer.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/QueueProducer.java)
-* [QueueConsumer.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/QueueConsumer.java)
+* [QueueProducer.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/QueueProducer.java)
+* [QueueConsumer.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/QueueConsumer.java)
 
 
 Learn how to verify all messages arrive to the Solace message router in our next tutorial, [Confirmed Delivery](../confirmed-delivery/).
@@ -212,8 +212,8 @@ Learn how to verify all messages arrive to the Solace message router in our next
 This tutorial is available in GitHub.  To get started, clone the GitHub repository containing the Solace samples.
 
 ```
-git clone https://github.com/SolaceSamples/solace-samples-java
-cd solace-samples-java
+git clone https://github.com/SolaceSamples/solace-samples-java-jcsmp
+cd solace-samples-java-jcsmp
 ```
 
 ### Building

--- a/src/pages/tutorials/jcsmp/publish-subscribe.md
+++ b/src/pages/tutorials/jcsmp/publish-subscribe.md
@@ -141,18 +141,18 @@ At this point the producer has sent a message to the Solace message router and y
 
 ## Summarizing
 
-The full source code for this example is available in [GitHub](https://github.com/SolaceSamples/solace-samples-java). If you combine the example source code shown above results in the following source:
+The full source code for this example is available in [GitHub](https://github.com/SolaceSamples/solace-samples-java-jcsmp). If you combine the example source code shown above results in the following source:
 
-* [TopicPublisher.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/TopicPublisher.java)
-* [TopicSubscriber.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/TopicSubscriber.java)
+* [TopicPublisher.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/TopicPublisher.java)
+* [TopicSubscriber.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/TopicSubscriber.java)
 
 ### Getting the Source
 
 This tutorial is available in GitHub.  To get started, clone the GitHub repository containing the Solace samples.
 
 ```
-git clone https://github.com/SolaceSamples/solace-samples-java
-cd solace-samples-java
+git clone https://github.com/SolaceSamples/solace-samples-java-jcsmp
+cd solace-samples-java-jcsmp
 ```
 
 ### Building

--- a/src/pages/tutorials/jcsmp/request-reply.md
+++ b/src/pages/tutorials/jcsmp/request-reply.md
@@ -166,18 +166,18 @@ try {
 
 ## Summarizing
 
-The full source code for this example is available in [GitHub](https://github.com/SolaceSamples/solace-samples-java). If you combine the example source code shown above results in the following source:
+The full source code for this example is available in [GitHub](https://github.com/SolaceSamples/-jcsmp). If you combine the example source code shown above results in the following source:
 
-* [BasicRequestor.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/BasicRequestor.java)
-* [BasicReplier.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/BasicReplier.java)
+* [BasicRequestor.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/BasicRequestor.java)
+* [BasicReplier.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/BasicReplier.java)
 
 ### Getting the Source
 
 This tutorial is available in GitHub.  To get started, clone the GitHub repository containing the Solace samples.
 
 ```
-git clone https://github.com/SolaceSamples/solace-samples-java
-cd solace-samples-java
+git clone https://github.com/SolaceSamples/solace-samples-java-jcsmp
+cd solace-samples-java-jcsmp
 ```
 
 ### Building

--- a/src/pages/tutorials/jcsmp/topic-to-queue-mapping.md
+++ b/src/pages/tutorials/jcsmp/topic-to-queue-mapping.md
@@ -131,17 +131,17 @@ try {
 
 ## Summarizing
 
-The full source code for this example is available in [GitHub](https://github.com/SolaceSamples/solace-samples-java). If you combine the example source code shown above results in the following source:
+The full source code for this example is available in [GitHub](https://github.com/SolaceSamples/solace-samples-java-jcsmp). If you combine the example source code shown above results in the following source:
 
-[TopicToQueueMapping.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/TopicToQueueMapping.java)
+[TopicToQueueMapping.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/TopicToQueueMapping.java)
 
 ### Getting the Source
 
 This tutorial is available in GitHub.  To get started, clone the GitHub repository containing the Solace samples.
 
 ```
-git clone https://github.com/SolaceSamples/solace-samples-java
-cd solace-samples-java
+git clone https://github.com/SolaceSamples/solace-samples-java-jcsmp
+cd solace-samples-java-jcsmp
 ```
 
 ### Building

--- a/src/pages/tutorials/jcsmp/transactions.md
+++ b/src/pages/tutorials/jcsmp/transactions.md
@@ -78,7 +78,7 @@ public void onReceive(BytesXMLMessage message) {
 
 ## Learn More
 
-* Related Source Code: [Transactions.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/features/Transactions.java)
+* Related Source Code: [Transactions.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/Transactions.java)
 * [Solace Feature Documentation](https://docs.solace.com/Solace-JMS-API/Using-Transacted-Sessions.htm?Highlight=Transactions)
 
 

--- a/src/pages/tutorials/jcsmp/ttl-and-dmq.md
+++ b/src/pages/tutorials/jcsmp/ttl-and-dmq.md
@@ -94,5 +94,5 @@ Thread.sleep(1000);
 
 ## Learn More
 
-* Related Source Code: [MessageTTLAndDeadMessageQueue.java](https://github.com/SolaceSamples/solace-samples-java/blob/master/src/main/java/com/solace/samples/features/MessageTTLAndDeadMessageQueue.java)
+* Related Source Code: [MessageTTLAndDeadMessageQueue.java](https://github.com/SolaceSamples/solace-samples-java-jcsmp/blob/master/src/main/java/com/solace/samples/jcsmp/features/MessageTTLAndDeadMessageQueue.java)
 * [Solace Feature Documentation](https://docs.solace.com/Solace-JMS-API/Setting-Message-Properties.htm?Highlight=Time%20to%20live)

--- a/src/pages/tutorials/jcsmp/tutorials.yml
+++ b/src/pages/tutorials/jcsmp/tutorials.yml
@@ -3,5 +3,5 @@
   icon: java.svg
   buttons:
     doclink: https://docs.solace.com/Solace-PubSub-Messaging-APIs/Java-API/java-api-home.htm
-    github: https://github.com/SolaceSamples/solace-samples-java
+    github: https://github.com/SolaceSamples/solace-samples-java-jcsmp
   type: solace

--- a/src/pages/tutorials/tanzu/java-app.md
+++ b/src/pages/tutorials/tanzu/java-app.md
@@ -153,7 +153,7 @@ logger.info("Solace client initializing and using Credentials: " + solaceCredent
 
 ### Connecting to the Solace Messaging Service
 
-Once the credentials are extracted, you can create and then connect the Solace Session in the conventional way as outlined in the [Publish/Subscribe tutorial](../../solace-samples-java/publish-subscribe/). You set the JCSMP properties and then use the `JCSMPFactory` to create a `Session`:
+Once the credentials are extracted, you can create and then connect the Solace Session in the conventional way as outlined in the [Publish/Subscribe tutorial](../../jcsmp/publish-subscribe/). You set the JCSMP properties and then use the `JCSMPFactory` to create a `Session`:
 
 ```java
 
@@ -253,7 +253,7 @@ public ResponseEntity<SimpleMessage> getLastMessageReceived() {
 
 The subscription JSON document used by the `/subscription` endpoint is modeled by the `SimpleSubscription` class, whereas the `/message` endpoint JSON document is modeled by the `SimpleMessage` class.
 
-For more details on sending and receiving messages, you can checkout the [JCSMP Publish/Subscribe tutorial](../../solace-samples-java/publish-subscribe/).
+For more details on sending and receiving messages, you can checkout the [JCSMP Publish/Subscribe tutorial](../../jcsmp/publish-subscribe/).
 
 ## Building
 

--- a/src/pages/tutorials/tanzu/spring-cloud-autoconf-java.md
+++ b/src/pages/tutorials/tanzu/spring-cloud-autoconf-java.md
@@ -153,7 +153,7 @@ for (SolaceServiceCredentials discoveredSolaceMessagingService : springJCSMPFact
 
 ### Connecting to the Solace PubSub+ Service
 
-The `SpringJCSMPFactory solaceFactory` was already autowired, you can use it to connect the Solace Session in the conventional way as outlined in the [Publish/Subscribe tutorial](../../solace-samples-java/publish-subscribe/). Use the `solaceFactory` to create a `Session`:
+The `SpringJCSMPFactory solaceFactory` was already autowired, you can use it to connect the Solace Session in the conventional way as outlined in the [Publish/Subscribe tutorial](../../jcsmp/publish-subscribe/). Use the `solaceFactory` to create a `Session`:
 
 ```java
 try {
@@ -244,7 +244,7 @@ public ResponseEntity<SimpleMessage> getLastMessageReceived() {
 
 The subscription JSON document used by the `/subscription` endpoint is modeled by the `SimpleSubscription` class, whereas the `/message` endpoint JSON document is modeled by the `SimpleMessage` class.
 
-For more details on sending and receiving messages, you can checkout the [JCSMP Publish/Subscribe tutorial](../../solace-samples-java/publish-subscribe/).
+For more details on sending and receiving messages, you can checkout the [JCSMP Publish/Subscribe tutorial](../../jcsmp/publish-subscribe/).
 
 ## Building
 

--- a/src/pages/tutorials/tanzu/spring-cloud-autoconf-jms.md
+++ b/src/pages/tutorials/tanzu/spring-cloud-autoconf-jms.md
@@ -271,7 +271,7 @@ public ResponseEntity<SimpleMessage> getLastMessageReceived() {
 
 The subscription JSON document used by the `/subscription` endpoint is modeled by the `SimpleSubscription` class, whereas the `/message` endpoint JSON document is modeled by the `SimpleMessage` class.
 
-For more details on sending and receiving messages, you can checkout the [JCSMP Publish/Subscribe tutorial](../../solace-samples-java/publish-subscribe/).
+For more details on sending and receiving messages, you can checkout the [JCSMP Publish/Subscribe tutorial](../../jcsmp/publish-subscribe/).
 
 ## Building
 

--- a/src/pages/tutorials/tanzu/spring-cloud-autoconf-jndi.md
+++ b/src/pages/tutorials/tanzu/spring-cloud-autoconf-jndi.md
@@ -340,7 +340,7 @@ public ResponseEntity<SimpleMessage> getLastMessageReceived() {
 
 The subscription JSON document used by the `/subscription` endpoint is modeled by the `SimpleSubscription` class, whereas the `/message` endpoint JSON document is modeled by the `SimpleMessage` class.
 
-For more details on sending and receiving messages, you can checkout the [JCSMP Publish/Subscribe tutorial](../../solace-samples-java/publish-subscribe/).
+For more details on sending and receiving messages, you can checkout the [JCSMP Publish/Subscribe tutorial](../../jcsmp/publish-subscribe/).
 
 ## Building
 

--- a/src/pages/tutorials/tanzu/spring-cloud.md
+++ b/src/pages/tutorials/tanzu/spring-cloud.md
@@ -125,7 +125,7 @@ if (solaceServiceCredentials == null) {
 
 ### Connecting to the Solace PubSub+ Service
 
-Once you have the `SolaceServiceCredentials`, you can create and then connect the Solace Session in the conventional way as outlined in the [Publish/Subscribe tutorial](../../solace-samples-java/publish-subscribe/). You set the JCSMP properties and then use the `JCSMPFactory` to create a `Session`:
+Once you have the `SolaceServiceCredentials`, you can create and then connect the Solace Session in the conventional way as outlined in the [Publish/Subscribe tutorial](../../jcsmp/publish-subscribe/). You set the JCSMP properties and then use the `JCSMPFactory` to create a `Session`:
 
 ```java
 final JCSMPProperties properties = new JCSMPProperties();
@@ -225,7 +225,7 @@ public ResponseEntity<SimpleMessage> getLastMessageReceived() {
 
 The subscription JSON document used by the `/subscription` endpoint is modeled by the `SimpleSubscription` class, whereas the `/message` endpoint JSON document is modeled by the `SimpleMessage` class.
 
-For more details on sending and receiving messages, you can checkout the [JCSMP Publish/Subscribe tutorial](../../solace-samples-java/publish-subscribe/).
+For more details on sending and receiving messages, you can checkout the [JCSMP Publish/Subscribe tutorial](../../jcsmp/publish-subscribe/).
 
 ## Building
 


### PR DESCRIPTION
 - updated GitHub samples repo name
 - updated URLs in tutorials to match
 - fixed a few Tanzu ones that were broke anyhow
 - 