### PR TITLE
updated jms lib version and fixed heading

### DIFF
--- a/src/pages/tutorials/common-assets/jmsApi.md
+++ b/src/pages/tutorials/common-assets/jmsApi.md
@@ -1,7 +1,7 @@
 
-## Obtaining Apache Qpid JMS 1.1
+## Obtaining Apache Qpid JMS
 
-This tutorial assumes you have downloaded and successfully installed the [Apache Qpid JMS client](https://qpid.apache.org/components/jms/index.html). If your environment differs from the example, then adjust the build instructions appropriately.
+This tutorial assumes you have downloaded and successfully installed the [Apache Qpid JMS client](https://qpid.apache.org/components/jms). If your environment differs from the example, then adjust the build instructions appropriately.
 
 The easiest way to install it is through Gradle or Maven.
 
@@ -9,7 +9,7 @@ The easiest way to install it is through Gradle or Maven.
 
 ```
 dependencies {
-    compile("org.apache.qpid:qpid-jms-client:0.27.0")
+    compile("org.apache.qpid:qpid-jms-client:1.6.0")
 }
 ```
 
@@ -19,6 +19,6 @@ dependencies {
 <dependency>
     <groupId>org.apache.qpid</groupId>
     <artifactId>qpid-jms-client</artifactId>
-    <version>0.27.0</version>
+    <version>1.6.0</version>
 </dependency>
 ```


### PR DESCRIPTION
As requested by Markus, updating tutorials to now make JMS 1.1 reference in 2.0 tutorials.
And updated the JAR lib version to match latest available, after testing it worked in samples.
