### PR TITLE
Typo fixes for C

### DIFF
--- a/src/pages/tutorials/c/topic-to-queue-mapping.md
+++ b/src/pages/tutorials/c/topic-to-queue-mapping.md
@@ -164,7 +164,7 @@ Binary Attachment:                      len=16
 Acknowledging message Id: 2.
 Exiting.
 ```
-On `TopicSubscriber` subswcribing to `my/sample/topic/1`
+On `TopicSubscriber` subscribing to `my/sample/topic/1`
 ```
 TopicSubscriber initializing...
 Connected.
@@ -180,7 +180,7 @@ Message Id:                             1
 Binary Attachment:                      len=16
   6d 79 20 61 74 74 61 63  68 65 64 20 64 61 74 61      my attac   hed data
 ```
-On `TopicSubscriber` subswcribing to `my/sample/topic/2`
+On `TopicSubscriber` subscribing to `my/sample/topic/2`
 ```
 opicSubscriber initializing...
 Connected.


### PR DESCRIPTION
As discussed @TamimiGitHub, I found some typos that needed to be fixed up;

<img width="1728" alt="Screen Shot 2022-09-28 at 1 52 11 PM" src="https://user-images.githubusercontent.com/6960616/192888854-0f20adbc-2c5a-404f-b333-9c8332a5e028.png">
