### PR TITLE
Add CSS styling for Osano dialog drawer

### DIFF
--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -1,3 +1,4 @@
+@import "osano.css";
 @import "card.css";
 @import "tutorialCards.css";
 @import "howtoCards.css";

--- a/src/css/osano.css
+++ b/src/css/osano.css
@@ -1,0 +1,77 @@
+.osano-cm-window {
+  color: #fff;
+}
+.osano-cm-info-dialog__info .osano-cm-info-dialog-header p {
+  font-weight: 600;
+  font-size: 18px;
+  color: #fff;
+}
+.osano-cm-info-dialog__info p {
+  font-size: 15px;
+  line-height: 1.4;
+  color: #fff;
+}
+.osano-cm-drawer-toggle .osano-cm-label {
+  font-size: 15px;
+  line-height: 1;
+  margin: 0 auto 0 0;
+  font-weight: 600;
+  color: #fff;
+}
+.osano-cm-button {
+  background-color: #00c895;
+  border-color: #00c895;
+  color: #000;
+  padding: 15px 5px;
+  border-radius: 50px;
+  font-weight: 600;
+  font-size: 16px;
+  font-family: "open-sans", Tahoma, Verdana, sans-serif;
+}
+.osano-cm-powered-by {
+  margin: 10px 0 0;
+  color: #fff;
+}
+.osano-cm-info-dialog-header__close:focus {
+  outline: none;
+  outline-offset: 0rem;
+}
+.osano-cm-close,
+.osano-cm-info-dialog-header__close {
+  padding: 5px;
+  text-align: center;
+  stroke: #000 !important;
+  border-color: #00c895 !important;
+  background-color: #00c895 !important;
+  outline: none;
+}
+.osano-cm-close svg,
+.osano-cm-info-dialog-header__close svg {
+  height: 16px;
+  width: 16px;
+  position: relative;
+  display: block;
+  margin: auto;
+}
+.osano-cm-powered-by .osano-cm-link {
+  color: #666;
+}
+.osano-cm-widget {
+  border-radius: 50%;
+  overflow: hidden;
+}
+.osano-cm-close:focus,
+.osano-cm-widget:focus {
+  outline: 1px solid #000;
+}
+.osano-cm-widget--position_left {
+  left: 5px;
+  bottom: 5px;
+}
+.osano-cm-dialog--type_bar .osano-cm-button {
+  margin-right: 25px;
+}
+.osano-cm-widget--position_right {
+  right: 20px;
+  bottom: 50px;
+}


### PR DESCRIPTION
PR which contains CSS styles to resolve an accessibility issue, with the colour of text used in new our cookie consent tool Osano.

![Screenshot 2023-11-01 at 11 28 43 AM](https://github.com/SolaceDev/solace-dev-tutorials/assets/6960616/348c1b52-6ddc-4469-ab50-b5808a9a8fb5)
