### PR TITLE
EBP-348: Fix Typo in C Persistence with Queues page

### DIFF
--- a/src/pages/tutorials/c/persistence-with-queues.md
+++ b/src/pages/tutorials/c/persistence-with-queues.md
@@ -180,7 +180,7 @@ flowEventCallback ( solClient_opaqueFlow_pt opaqueFlow_p, solClient_flow_eventCa
  * Create a Flow
 *************************************************************************/
 /* Flow Properties */
-const char     *flowProps[20] = (0, };
+const char     *flowProps[20] = {0, };
 
 /* Flow */
 solClient_opaqueFlow_pt flow_p;


### PR DESCRIPTION
This is a fix for pages/tutorials/c/persistence-with-queues.md, where there was a typo in the code under the ["Receiving a message from a queue" section](https://tutorials.solace.dev/c/persistence-with-queues/#Receiving-a-message-from-a-queue). 